### PR TITLE
Fixed go module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module paymentpage
+module github.com/Jetpay/paymentpage-sdk-go
 
 go 1.20
 


### PR DESCRIPTION
Командна `go get github.com/Jetpay/paymentpage-sdk-go` не работает на данный момент, так как нужно переименовать название модуля.